### PR TITLE
copyNote Fix for 2.1.38

### DIFF
--- a/copyNote.py
+++ b/copyNote.py
@@ -73,14 +73,16 @@ def copyNote(nid):
     if getUserOption("relate copies", False):
         if not getRelationsFromNote(note):
             note.addTag(createRelationTag())
-            note.flush()
+            note.id = 0
+            mw.col.addNote(note)
     note.id = timestampID(note.col.db, "notes", note.id if getUserOption(
         "Preserve creation time", True) else None)
     note.guid = guid64()
     for card in cards:
         copyCard(card, note)
     note.addTag(getUserOption("tag for copies"))
-    note.flush()
+    note.id = 0
+    mw.col.addNote(note)
 
 
 def copyCard(card, note):


### PR DESCRIPTION
This is a fix for #20 and possible #19

I was running into an issue on 2.1.38 when trying to copy a note

```
Caught exception:
Traceback (most recent call last):
  File "/Users/garrett2/Library/Application Support/Anki2/addons21/1566928056/copyNote.py", line 65, in <lambda>
    a.triggered.connect(lambda: copyNotes(browser.selectedNotes()))
  File "/Users/garrett2/Library/Application Support/Anki2/addons21/1566928056/copyNote.py", line 52, in copyNotes
    copyNote(nid)
  File "/Users/garrett2/Library/Application Support/Anki2/addons21/1566928056/copyNote.py", line 83, in copyNote
    note.flush()
  File "anki/notes.py", line 68, in flush
  File "anki/rsbackend_gen.py", line 364, in update_note
  File "anki/rsbackend.py", line 256, in _run_command
```

I drilled down and found the source of the issue was some [newly added error handling](https://github.com/ankitects/anki/blob/2e193c3e5b93004aea51dfa11d93b20698286998/rslib/src/notes.rs#L273-L281). See [this issue](https://forums.ankiweb.net/t/bug-report-editor-updating-non-existing-card/2117) for more details.

The solution was to use `addNote` instead. I also had to set the id to 0 first because of a [rust assertion](https://github.com/ankitects/anki/blob/2e193c3e5b93004aea51dfa11d93b20698286998/rslib/src/storage/note/mod.rs#L64).

Keep in mind, `addNote` in `collection.py` is legacy and likely to break again. `add_note` should be used instead, but it requires you to provide a `deck_id` and this PR only contains the code changes that I got working on my machine.