### PR TITLE
When not preserving 'due', ensure it's scheduled as a new card

### DIFF
--- a/copyNote.py
+++ b/copyNote.py
@@ -74,7 +74,7 @@ def copyNote(nid):
     cards = note.cards()
     oid = note.id
 
-    note_copy = add_note_with_id()
+    note_copy, copy_due = add_note_with_id()
     note.id = note_copy.id
     note.guid = note_copy.guid
 
@@ -84,7 +84,7 @@ def copyNote(nid):
             note.addTag(createRelationTag())
             note.flush()
     for card in cards:
-        copyCard(card, note)
+        copyCard(card, note, copy_due)
     note.addTag(getUserOption("tag for copies"))
     note.flush()
     if getUserOption(
@@ -93,7 +93,7 @@ def copyNote(nid):
         mw.col.db.execute("update cards set nid = ? where nid = ?", new_nid, note.id)
 
 
-def copyCard(card, note):
+def copyCard(card, note, copy_due):
     oid = card.id
     # Setting id to 0 is Card is seen as new; which lead to a different process in backend
     card.id = 0
@@ -106,6 +106,7 @@ def copyCard(card, note):
         card.lapses = 0
         card.left = 0
         card.odue = 0
+        card.due = copy_due
     card.nid = note.id
     card.flush()
     if getUserOption(

--- a/new_note_id.py
+++ b/new_note_id.py
@@ -6,6 +6,7 @@ def add_note_with_id(id: Optional[int]= None):
     """Add a note, in the db with unique guid, and id as close as id possible, (now if id=None), without card."""
     note = mw.col.newNote()
     mw.col.add_note(note, 1)
+    due = mw.col.db.scalar("select due from cards where nid = ?", note.id)
     mw.col.db.execute("delete from cards where nid = ?", note.id)
     new_id = timestampID(note.col.db, "notes", id)
     mw.col.db.execute("""
@@ -14,5 +15,4 @@ def add_note_with_id(id: Optional[int]= None):
     where id=?
     """, new_id, note.id)
     note.id = new_id
-    return note
-    
+    return note, due


### PR DESCRIPTION
I have "Preserve ease, due, interval..." set to false, and I've been running into an issue where I copy from existing cards I've already reviewed before, but the due field gets copied over from the already reviewed card, creating a 'due' which is very low and confuses Anki into scheduling the card as a non-new card, even though it displays as a new card in the browser. For example, it'll say something like "New #1234" in the browser instead of something like "New #2000001", where that 1234 is the due date in days of the old card, and something in Anki sees that and schedules it like I've already reviewed it for some reason.

Because of this, I have to select my copied cards and click "Reposition" or "Forget" to make the due field update appropriately. This fix is to make that happen automatically.