### PR TITLE
Allow for leaving specific fields empty in copied note

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ the new copied note. Otherwise, a new tag will be added to both.
 * **relate copies** *(Default = True)*: Add a tag to relate the original note and its copy for the [Bury related notes add-on](https://ankiweb.net/shared/info/413416269)
 * **tag prefixes** *(Default = ['relation_'])*: if a copied note's tag contain a prefix in this list, no prefix will be added. As in the [Bury related notes add-on](https://ankiweb.net/shared/info/413416269)
 * **tag for copies** *(Default = 'copy')*: A tag added to the new notes, copied from another note.
+* **fields to leave empty in copy** *(Default = [])*: Specific fields to leave empty in the copied note.
+* **leave all fields empty in copy** *(Default = False)*: Leave all fields empty in the copied note.
 
 ## Links, licence and credits
 

--- a/config.json
+++ b/config.json
@@ -7,5 +7,7 @@
   "current tag prefix": "relation_",
   "tag prefixes": ["relation_"],
   "relate copies": false,
-  "tag for copies": "Copy"
+  "tag for copies": "Copy",
+  "fields to leave empty in copy": [],
+  "leave all fields empty in copy": false
 }

--- a/copyNote.py
+++ b/copyNote.py
@@ -86,6 +86,7 @@ def copyNote(nid):
     for card in cards:
         copyCard(card, note)
     note.addTag(getUserOption("tag for copies"))
+    emptyIgnoredFields(note)
     note.flush()
     if getUserOption(
             "Preserve creation time", True):
@@ -124,6 +125,14 @@ def copyLog(data, newCid):
     mw.col.db.execute("insert into revlog values (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                       id, cid, usn, ease, ivl, lastIvl, factor, time, type)
 
+def emptyIgnoredFields(note):
+    if (getUserOption("leave all fields empty in copy", False)):
+        for key in note.keys():
+            note[key] = "";
+    fieldsToEmpty = getUserOption("fields to leave empty in copy", [])
+    for field in fieldsToEmpty:
+        if field in note:
+            note[field] = ""
 
 addHook("browser.setupMenus", setupMenu)
 


### PR DESCRIPTION
Small feature I find useful, if you're interested. Often when copying my notes my goal is to actually create new notes without having to leave the card browser, so what I'll do is copy a note that has the note type I'm looking for, empty the fields I don't need anymore, and then fill in the note like I would in the "Add" window. Since I leave the Anki browser open all the time, this saves me a few clicks of getting to the Add window, but also forces me to manually empty out fields I don't need in the new note. This is a small change to help with that, by letting you specify any fields (or all fields) you don't want to get copied over.

My use case is probably a bit weird considering the goal of the addon, but I think this feature would also come in handy for anyone else fine tuning how they want things to get copied.