### PR TITLE
Ensure new cards are scheduled as new

### DIFF
--- a/copyNote.py
+++ b/copyNote.py
@@ -98,7 +98,8 @@ def copyCard(card, note):
     # Setting id to 0 is Card is seen as new; which lead to a different process in backend
     card.id = 0
     new_cid = timestampID(note.col.db, "cards", oid)
-    if not getUserOption("Preserve ease, due, interval...", True):
+    shouldNotPreserveScheduling = not getUserOption("Preserve ease, due, interval...", True)
+    if shouldNotPreserveScheduling:
         card.type = 0
         card.ivl = 0
         card.factor = 0
@@ -108,6 +109,8 @@ def copyCard(card, note):
         card.odue = 0
     card.nid = note.id
     card.flush()
+    if shouldNotPreserveScheduling:
+        mw.col.sched.schedule_cards_as_new([card.id])
     if getUserOption(
             "Preserve creation time", True):
         mw.col.db.execute("update Cards set id = ? where id = ?", new_cid, card.id)


### PR DESCRIPTION
When using the V2 scheduler, there's a field called 'queue' on the cards table that should be set to 0 when copying to a new card, but it's not getting reset when ignoring scheduling information. This creates a weird situation where the new card gets displayed as "New" in the Anki browser but won't necessarily appear in your queue of new cards, specifically if the card you copied has already been reviewed before. The best way to guarantee this doesn't happen should be to use the same function Anki uses when you click "Forget" or "Reposition" on a card (which is what I've been using to workaround this issue).