### PR TITLE
Replace deprecated note.addTag with note.add_tag

### DIFF
--- a/copyNote.py
+++ b/copyNote.py
@@ -83,12 +83,12 @@ def copyNote(nid):
 
     if getUserOption("relate copies", False):
         if not getRelationsFromNote(note):
-            note.addTag(createRelationTag())
+            note.add_tag(createRelationTag())
             note.flush()
     for old, new in zip(old_cards_sorted, new_cards_sorted):
         copyCard(old, new)
     
-    note.addTag(getUserOption("tag for copies"))
+    note.add_tag(getUserOption("tag for copies"))
     note.usn = mw.col.usn()
     note.flush()
 


### PR DESCRIPTION
Thanks for your work on this but also in general! Not sure whether you prefer large PRs replacing deprecated parts or smaller more manageable ones. I used the copyNote function and it currently gives a warning since addTag is used rather than add_tag so I just replaced that.